### PR TITLE
Used sendall() instead of send() to make sure all bytes are sent.

### DIFF
--- a/sievelib/managesieve.py
+++ b/sievelib/managesieve.py
@@ -243,9 +243,9 @@ class Client(object):
         if len(args):
             tosend += " " + " ".join(self.__prepare_args(args))
         self.__dprint("Command: %s" % tosend)
-        self.sock.send("%s%s" % (tosend, CRLF))
+        self.sock.sendall("%s%s" % (tosend, CRLF))
         for l in extralines:
-            self.sock.send("%s%s" % (l, CRLF))
+            self.sock.sendall("%s%s" % (l, CRLF))
         code, data, content = self.__read_response(nblines)
 
         if withcontent:


### PR DESCRIPTION
When sending a large sieve script with putscript the following error occured: "Failed to read data from the server"

This was due to the fact that send() didn't sent all bytes, and this is not checked.

Fixed by using sendall() instead of send()
