### PR TITLE
Include the utf-8 test file in the source tarball.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.rst COPYING requirements.txt
+include sievelib/tests/files/utf8_sieve.txt


### PR DESCRIPTION
This allows the tests to be run if someone downloads the tarball from pypi (like
the [Debian package](https://packages.qa.debian.org/p/python-sievelib.html) does).