### PR TITLE
provide support for non-IPv4 connections

### DIFF
--- a/sievelib/managesieve.py
+++ b/sievelib/managesieve.py
@@ -479,8 +479,7 @@ class Client(object):
         :rtype: boolean
         """
         try:
-            self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            self.sock.connect((self.srvaddr, self.srvport))
+            self.sock = socket.create_connection((self.srvaddr, self.srvport))
             self.sock.settimeout(Client.read_timeout)
         except socket.error as msg:
             raise Error("Connection to server failed: %s" % str(msg))


### PR DESCRIPTION
Use socket.create_connection() when establishing the server connection.
This avoids hardcoding AF_INET and thus introduces support for IPv6