### PR TITLE
Python 3 compatibility

### DIFF
--- a/sievelib/commands.py
+++ b/sievelib/commands.py
@@ -27,7 +27,6 @@ from collections import Iterable
 import sys
 
 from future.utils import python_2_unicode_compatible
-import six
 
 
 @python_2_unicode_compatible
@@ -158,8 +157,6 @@ class Command(object):
                     continue
 
                 if "string" in arg["type"]:
-                    if isinstance(value, six.binary_type):
-                        value = value.decode("utf-8")
                     target.write(value)
                     if not value.startswith('"'):
                         target.write("\n")
@@ -409,7 +406,7 @@ class RequireCommand(ControlCommand):
     loaded_extensions = []
 
     def complete_cb(self):
-        if type(self.arguments["capabilities"]) == str:
+        if type(self.arguments["capabilities"]) != list:
             exts = [self.arguments["capabilities"]]
         else:
             exts = self.arguments["capabilities"]

--- a/sievelib/factory.py
+++ b/sievelib/factory.py
@@ -82,7 +82,7 @@ class FiltersSet(object):
                     name = comment.replace(self.filter_name_pretext, "")
                 if comment.startswith(self.filter_desc_pretext):
                     description = comment.replace(self.filter_desc_pretext, "")
-            self.filters += [{"name": self._unicode_filter_name(name),
+            self.filters += [{"name": name,
                               "description": description,
                               "content": f,
                               "enabled": not self.__isdisabled(f)}]
@@ -409,10 +409,9 @@ class FiltersSet(object):
             cmd.tosieve(target=target)
             target.write(u"\n")
         for f in self.filters:
-            target.write("{0}{1}\n".format(self.filter_name_pretext,
-                                           f["name"]))
+            target.write("{}{}\n".format(self.filter_name_pretext, f["name"]))
             if "description" in f and f["description"]:
-                target.write(u"{0}{1}\n".format(
+                target.write(u"{}{}\n".format(
                     self.filter_desc_pretext, f["description"]))
             f["content"].tosieve(target=target)
 

--- a/sievelib/parser.py
+++ b/sievelib/parser.py
@@ -14,7 +14,7 @@ import codecs
 import re
 import sys
 
-from future.utils import python_2_unicode_compatible
+from future.utils import python_2_unicode_compatible, text_type
 
 from sievelib.commands import (
     get_command_instance, UnknownCommand, BadArgument, BadValue
@@ -42,21 +42,21 @@ class Lexer(object):
     Patterns are provided into a list of 2-uple. Each 2-uple consists
     of a token name and an associated pattern, example:
 
-      [("left_bracket", r'\['),]
+      [(b"left_bracket", br'\['),]
     """
 
     def __init__(self, definitions):
         self.definitions = definitions
         parts = []
         for name, part in definitions:
-            parts.append("(?P<%s>%s)" % (name, part))
-        self.regexpString = "|".join(parts)
+            parts.append(b"(?P<%s>%s)" % (name, part))
+        self.regexpString = b"|".join(parts)
         self.regexp = re.compile(self.regexpString, re.MULTILINE)
-        self.wsregexp = re.compile(r'\s+', re.M)
+        self.wsregexp = re.compile(br'\s+', re.M)
 
     def curlineno(self):
         """Return the current line number"""
-        return self.text[:self.pos].count('\n') + 1
+        return self.text[:self.pos].count(b'\n') + 1
 
     def scan(self, text):
         """Analyse some data
@@ -67,7 +67,7 @@ class Lexer(object):
 
         On error, a ParseError exception is raised.
 
-        :param text: a string containing the data to parse
+        :param text: a binary string containing the data to parse
         """
         self.pos = 0
         self.text = text
@@ -92,21 +92,21 @@ class Parser(object):
     works with a Lexer object in order to check for grammar validity.
     """
     lrules = [
-        ("left_bracket", r'\['),
-        ("right_bracket", r'\]'),
-        ("left_parenthesis", r'\('),
-        ("right_parenthesis", r'\)'),
-        ("left_cbracket", r'{'),
-        ("right_cbracket", r'}'),
-        ("semicolon", r';'),
-        ("comma", r','),
-        ("hash_comment", r'#.*$'),
-        ("bracket_comment", r'/\*[\s\S]*?\*/'),
-        ("multiline", r'text:[^$]*?[\r\n]+\.$'),
-        ("string", r'"([^"\\]|\\.)*"'),
-        ("identifier", r'[a-zA-Z_][\w]*'),
-        ("tag", r':[a-zA-Z_][\w]*'),
-        ("number", r'[0-9]+[KMGkmg]?'),
+        (b"left_bracket", br'\['),
+        (b"right_bracket", br'\]'),
+        (b"left_parenthesis", br'\('),
+        (b"right_parenthesis", br'\)'),
+        (b"left_cbracket", br'{'),
+        (b"right_cbracket", br'}'),
+        (b"semicolon", br';'),
+        (b"comma", br','),
+        (b"hash_comment", br'#.*$'),
+        (b"bracket_comment", br'/\*[\s\S]*?\*/'),
+        (b"multiline", br'text:[^$]*?[\r\n]+\.$'),
+        (b"string", br'"([^"\\]|\\.)*"'),
+        (b"identifier", br'[a-zA-Z_][\w]*'),
+        (b"tag", br':[a-zA-Z_][\w]*'),
+        (b"number", br'[0-9]+[KMGkmg]?'),
     ]
 
     def __init__(self, debug=False):
@@ -223,7 +223,7 @@ class Parser(object):
                             ; are optional
         """
         if ttype == "string":
-            self.__curstringlist += [tvalue]
+            self.__curstringlist += [tvalue.decode("utf-8")]
             self.__set_expected("comma", "right_bracket")
             return True
         if ttype == "comma":
@@ -247,11 +247,11 @@ class Parser(object):
         :param tvalue: current token value
         :return: False if an error is encountered, True otherwise
         """
-        if ttype == "multiline":
-            return self.__curcommand.check_next_arg("string", tvalue)
+        if ttype in ["multiline", "string"]:
+            return self.__curcommand.check_next_arg("string", tvalue.decode("utf-8"))
 
-        if ttype in ["number", "tag", "string"]:
-            return self.__curcommand.check_next_arg(ttype, tvalue)
+        if ttype in ["number", "tag"]:
+            return self.__curcommand.check_next_arg(ttype, tvalue.decode("ascii"))
 
         if ttype == "left_bracket":
             self.__cstate = self.__stringlist
@@ -275,7 +275,7 @@ class Parser(object):
         :return: False if an error is encountered, True otherwise
         """
         if ttype == "identifier":
-            test = get_command_instance(tvalue, self.__curcommand)
+            test = get_command_instance(tvalue.decode("ascii"), self.__curcommand)
             self.__curcommand.check_next_arg("test", test)
             self.__expected = test.get_expected_first()
             self.__curcommand = test
@@ -323,7 +323,7 @@ class Parser(object):
 
             if ttype != "identifier":
                 return False
-            command = get_command_instance(tvalue, self.__curcommand)
+            command = get_command_instance(tvalue.decode("ascii"), self.__curcommand)
             if command.get_type() == "test":
                 raise ParseError("%s may not appear as a first command" % command.name)
             if command.get_type() == "control" and command.accept_children \
@@ -370,6 +370,9 @@ class Parser(object):
         :param text: a string containing the data to parse
         :return: True on success (no error detected), False otherwise
         """
+        if isinstance(text, text_type):
+            text = text.encode("utf-8")
+        
         self.__reset_parser()
         try:
             for ttype, tvalue in self.lexer.scan(text):
@@ -412,10 +415,9 @@ class Parser(object):
         :param name: the pathname of the file to parse
         :return: True on success (no error detected), False otherwise
         """
-        fp = codecs.open(name, encoding='utf8')
-        content = fp.read()
-        fp.close()
-        return self.parse(content)
+        with open(name, "rb") as fp:
+            return self.parse(fp.read())
+        
 
     def dump(self, target=sys.stdout):
         """Dump the parsing tree.

--- a/sievelib/tests/test_parser.py
+++ b/sievelib/tests/test_parser.py
@@ -83,7 +83,7 @@ class AdditionalCommands(SieveTest):
         )
         sievelib.commands.add_commands(MytestCommand)
         sievelib.commands.get_command_instance('mytest')
-        self.compilation_ok("""
+        self.compilation_ok(b"""
         mytest :testtag 10 ["testrecp1@example.com"];
         """)
 
@@ -107,7 +107,7 @@ class ValidEncodings(SieveTest):
 
 class ValidSyntaxes(SieveTest):
     def test_hash_comment(self):
-        self.compilation_ok("""
+        self.compilation_ok(b"""
 if size :over 100k { # this is a comment
     discard;
 }
@@ -121,7 +121,7 @@ if (type: control)
 """)
 
     def test_bracket_comment(self):
-        self.compilation_ok("""
+        self.compilation_ok(b"""
 if size :over 100K { /* this is a comment
     this is still a comment */ discard /* this is a comment
     */ ;
@@ -136,7 +136,7 @@ if (type: control)
 """)
 
     def test_string_with_bracket_comment(self):
-        self.compilation_ok("""
+        self.compilation_ok(b"""
 if header :contains "Cc" "/* comment */" {
     discard;
 }
@@ -151,7 +151,7 @@ if (type: control)
 """)
 
     def test_multiline_string(self):
-        self.compilation_ok("""
+        self.compilation_ok(b"""
 require "reject";
 
 if allof (false, address :is ["From", "Sender"] ["blka@bla.com"]) {
@@ -200,7 +200,7 @@ Your email has been canceled too
 """)
 
     def test_nested_blocks(self):
-        self.compilation_ok("""
+        self.compilation_ok(b"""
 if header :contains "Sender" "example.com" {
   if header :contains "Sender" "me@" {
     discard;
@@ -230,7 +230,7 @@ if (type: control)
 """)
 
     def test_true_test(self):
-        self.compilation_ok("""
+        self.compilation_ok(b"""
 if true {
 
 }
@@ -241,7 +241,7 @@ if (type: control)
 """)
 
     def test_rfc5228_extended(self):
-        self.compilation_ok("""
+        self.compilation_ok(b"""
 #
 # Example Sieve Filter
 # Declare any optional features or extension used by the script
@@ -319,7 +319,7 @@ else (type: control)
 """)
 
     def test_explicit_comparator(self):
-        self.compilation_ok("""
+        self.compilation_ok(b"""
 if header :contains :comparator "i;octet" "Subject" "MAKE MONEY FAST" {
   discard;
 }
@@ -335,7 +335,7 @@ if (type: control)
 """)
 
     def test_non_ordered_args(self):
-        self.compilation_ok("""
+        self.compilation_ok(b"""
 if address :all :is "from" "tim@example.com" {
     discard;
 }
@@ -351,7 +351,7 @@ if (type: control)
 """)
 
     def test_multiple_not(self):
-        self.compilation_ok("""
+        self.compilation_ok(b"""
 if not not not not true {
     stop;
 }
@@ -367,13 +367,13 @@ if (type: control)
 """)
 
     def test_just_one_command(self):
-        self.compilation_ok("keep;")
+        self.compilation_ok(b"keep;")
         self.representation_is("""
 keep (type: action)
 """)
 
     def test_singletest_testlist(self):
-        self.compilation_ok("""
+        self.compilation_ok(b"""
 if anyof (true) {
     discard;
 }
@@ -386,7 +386,7 @@ if (type: control)
 """)
 
     def test_truefalse_testlist(self):
-        self.compilation_ok("""
+        self.compilation_ok(b"""
 if anyof(true, false) {
     discard;
 }
@@ -400,7 +400,7 @@ if (type: control)
 """)
 
     def test_vacationext_basic(self):
-        self.compilation_ok("""
+        self.compilation_ok(b"""
 require "vacation";
 if header :contains "subject" "cyrus" {
     vacation "I'm out -- send mail to cyrus-bugs";
@@ -410,7 +410,7 @@ if header :contains "subject" "cyrus" {
 """)
 
     def test_vacationext_medium(self):
-        self.compilation_ok("""
+        self.compilation_ok(b"""
 require "vacation";
 if header :contains "subject" "lunch" {
     vacation :handle "ran-away" "I'm out and can't meet for lunch";
@@ -420,7 +420,7 @@ if header :contains "subject" "lunch" {
 """)
 
     def test_vacationext_with_limit(self):
-        self.compilation_ok("""
+        self.compilation_ok(b"""
 require "vacation";
 vacation :days 23 :addresses ["tjs@example.edu",
                               "ts4z@landru.example.edu"]
@@ -429,7 +429,7 @@ vacation :days 23 :addresses ["tjs@example.edu",
 """)
 
     def test_vacationext_with_multiline(self):
-        self.compilation_ok("""
+        self.compilation_ok(b"""
 require "vacation";
 vacation :mime text:
 Content-Type: multipart/alternative; boundary=foo
@@ -455,7 +455,7 @@ Mmmm, <A HREF="ocean.gif">surf</A>...
 """)
 
     def test_reject_extension(self):
-        self.compilation_ok("""
+        self.compilation_ok(b"""
 require "reject";
 
 if header :contains "subject" "viagra" {
@@ -466,43 +466,43 @@ if header :contains "subject" "viagra" {
 
 class InvalidSyntaxes(SieveTest):
     def test_nested_comments(self):
-        self.compilation_ko("""
+        self.compilation_ko(b"""
 /* this is a comment /* with a nested comment inside */
 it is allowed by the RFC :p */
 """)
 
     def test_nonopened_block(self):
-        self.compilation_ko("""
+        self.compilation_ko(b"""
 if header :is "Sender" "me@example.com" 
     discard;
 }
 """)
 
     def test_nonclosed_block(self):
-        self.compilation_ko("""
+        self.compilation_ko(b"""
 if header :is "Sender" "me@example.com" {
     discard;
 
 """)
 
     def test_unknown_token(self):
-        self.compilation_ko("""
+        self.compilation_ko(b"""
 if header :is "Sender" "Toto" & header :contains "Cc" "Tata" {
     
 }
 """)
 
     def test_empty_string_list(self):
-        self.compilation_ko("require [];")
+        self.compilation_ko(b"require [];")
 
     def test_unclosed_string_list(self):
-        self.compilation_ko('require ["toto", "tata";')
+        self.compilation_ko(b'require ["toto", "tata";')
 
     def test_misplaced_comma_in_string_list(self):
-        self.compilation_ko('require ["toto",];')
+        self.compilation_ko(b'require ["toto",];')
 
     def test_nonopened_tests_list(self):
-        self.compilation_ko("""
+        self.compilation_ko(b"""
 if anyof header :is "Sender" "me@example.com",
           header :is "Sender" "myself@example.com") {
     fileinto "trash";
@@ -510,7 +510,7 @@ if anyof header :is "Sender" "me@example.com",
 """)
 
     def test_nonclosed_tests_list(self):
-        self.compilation_ko("""
+        self.compilation_ko(b"""
 if anyof (header :is "Sender" "me@example.com",
           header :is "Sender" "myself@example.com" {
     fileinto "trash";
@@ -518,59 +518,59 @@ if anyof (header :is "Sender" "me@example.com",
 """)
 
     def test_nonclosed_tests_list2(self):
-        self.compilation_ko("""
+        self.compilation_ko(b"""
 if anyof (header :is "Sender" {
     fileinto "trash";
 }
 """)
 
     def test_misplaced_comma_in_tests_list(self):
-        self.compilation_ko("""
+        self.compilation_ko(b"""
 if anyof (header :is "Sender" "me@example.com",) {
 
 }
 """)
 
     def test_comma_inside_arguments(self):
-        self.compilation_ko("""
+        self.compilation_ko(b"""
 require "fileinto", "enveloppe";
 """)
 
     def test_non_ordered_args(self):
-        self.compilation_ko("""
+        self.compilation_ko(b"""
 if address "From" :is "tim@example.com" {
     discard;
 }
 """)
 
     def test_extra_arg(self):
-        self.compilation_ko("""
+        self.compilation_ko(b"""
 if address :is "From" "tim@example.com" "tutu" {
     discard;
 }
 """)
 
     def test_empty_not(self):
-        self.compilation_ko("""
+        self.compilation_ko(b"""
 if not {
     discard;
 }
 """)
 
     def test_missing_semicolon(self):
-        self.compilation_ko("""
+        self.compilation_ko(b"""
 require ["fileinto"]
 """)
 
     def test_missing_semicolon_in_block(self):
-        self.compilation_ko("""
+        self.compilation_ko(b"""
 if true {
     stop
 }
 """)
 
     def test_misplaced_parenthesis(self):
-        self.compilation_ko("""
+        self.compilation_ko(b"""
 if (true) {
 
 }
@@ -579,26 +579,26 @@ if (true) {
 
 class LanguageRestrictions(SieveTest):
     def test_unknown_control(self):
-        self.compilation_ko("""
+        self.compilation_ko(b"""
 macommande "Toto";
 """)
 
     def test_misplaced_elsif(self):
-        self.compilation_ko("""
+        self.compilation_ko(b"""
 elsif true {
 
 }
 """)
 
     def test_misplaced_elsif2(self):
-        self.compilation_ko("""
+        self.compilation_ko(b"""
 elsif header :is "From" "toto" {
 
 }
 """)
 
     def test_misplaced_nested_elsif(self):
-        self.compilation_ko("""
+        self.compilation_ko(b"""
 if true {
   elsif false {
 
@@ -607,43 +607,43 @@ if true {
 """)
 
     def test_unexpected_argument(self):
-        self.compilation_ko('stop "toto";')
+        self.compilation_ko(b'stop "toto";')
 
     def test_bad_arg_value(self):
-        self.compilation_ko("""
+        self.compilation_ko(b"""
 if header :isnot "Sent" "me@example.com" {
   stop;
 }
 """)
 
     def test_bad_arg_value2(self):
-        self.compilation_ko("""
+        self.compilation_ko(b"""
 if header :isnot "Sent" 10000 {
   stop;
 }
 """)
 
     def test_bad_comparator_value(self):
-        self.compilation_ko("""
+        self.compilation_ko(b"""
 if header :contains :comparator "i;prout" "Subject" "MAKE MONEY FAST" {
   discard;
 }
 """)
 
     def test_not_included_extension(self):
-        self.compilation_ko("""
+        self.compilation_ko(b"""
 if header :contains "Subject" "MAKE MONEY FAST" {
   fileinto "spam";
 }
 """)
 
     def test_test_outside_control(self):
-        self.compilation_ko("true;")
+        self.compilation_ko(b"true;")
 
 
 class DateCommands(SieveTest):
     def test_currentdate_command(self):
-        self.compilation_ok("""require ["date", "relational"];
+        self.compilation_ok(b"""require ["date", "relational"];
 
 if allof ( currentdate :value "ge" "date" "2013-10-23" , currentdate :value "le" "date" "2014-10-12" ) 
 {
@@ -652,7 +652,7 @@ if allof ( currentdate :value "ge" "date" "2013-10-23" , currentdate :value "le"
 """)
 
     def test_currentdate_command_timezone(self):
-        self.compilation_ok("""require ["date", "relational"];
+        self.compilation_ok(b"""require ["date", "relational"];
 
 if allof ( currentdate :zone "+0100" :value "ge" "date" "2013-10-23" , currentdate :value "le" "date" "2014-10-12" ) 
 {
@@ -661,7 +661,7 @@ if allof ( currentdate :zone "+0100" :value "ge" "date" "2013-10-23" , currentda
 """)
 
     def test_currentdate_norel(self):
-        self.compilation_ok("""require ["date"];
+        self.compilation_ok(b"""require ["date"];
 
 if allof ( 
   currentdate :zone "+0100" :is "date" "2013-10-23"  
@@ -673,7 +673,7 @@ if allof (
 
 class VariablesCommands(SieveTest):
     def test_set_command(self):
-        self.compilation_ok("""require ["variables"];
+        self.compilation_ok(b"""require ["variables"];
 
 set "matchsub" "testsubject";
         


### PR DESCRIPTION
Text vs Binary design choices for the managesieve protocol implementation:

  * All strings (including script filenames) are UTF-8 encoded/decoded (as mandated by the RFC)
  * Sieve scripts are stored and read as binary files

Text vs Binary Design choices made for the Sieve parser:

  * Sieve is parsed as binary (the way it is delivered by the managesieve protocol)
  * Strings in sieve are expected to always be UTF-8 encoded (may be a bad assumption but everything else would have required a lot more work)

All unit tests pass on both Python 2 & 3 except for `LanguageRestrictions.test_not_included_extension` was broken before already.