### PR TITLE
data maybe None after __read_response, handle that case

### DIFF
--- a/sievelib/managesieve.py
+++ b/sievelib/managesieve.py
@@ -270,7 +270,8 @@ class Client(object):
 
         if isinstance(code, six.binary_type):
             code = code.decode("utf-8")
-        data = data.decode("utf-8")
+        if isinstance(data, six.binary_type):
+            data = data.decode("utf-8")
 
         if withcontent:
             return (code, data, content)

--- a/sievelib/managesieve.py
+++ b/sievelib/managesieve.py
@@ -497,8 +497,7 @@ class Client(object):
         :rtype: boolean
         """
         try:
-            self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            self.sock.connect((self.srvaddr, self.srvport))
+            self.sock = socket.create_connection((self.srvaddr, self.srvport))
             self.sock.settimeout(Client.read_timeout)
         except socket.error as msg:
             raise Error("Connection to server failed: %s" % str(msg))


### PR DESCRIPTION
In `__send_command()`, `data ` maybe `None` after the call to `__read_response()`.

Don't call `data.decode()` unless `data` is actually binary.

This fixes connecting to Cyrus timsieved v2.4.19.