### PR TITLE
use socket.create_connection() instead of manual socket setup

### DIFF
--- a/sievelib/managesieve.py
+++ b/sievelib/managesieve.py
@@ -496,8 +496,7 @@ class Client(object):
         :rtype: boolean
         """
         try:
-            self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            self.sock.connect((self.srvaddr, self.srvport))
+            self.sock = socket.create_connection((self.srvaddr, self.srvport))
             self.sock.settimeout(Client.read_timeout)
         except socket.error as msg:
             raise Error("Connection to server failed: %s" % str(msg))


### PR DESCRIPTION
Python has had `socket.create_connection()` since 2.6, so it should be safe to use that instead of manually setting up a stream socket.

This should fix #60