### PR TITLE
Problems with pip >=10 and pip.req

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,10 @@ from __future__ import unicode_literals
 
 import io
 from os import path
-from pip.req import parse_requirements
+try: # for pip >= 10 (From: https://stackoverflow.com/questions/25192794/no-module-named-pip-req)
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
 from setuptools import setup, find_packages
 
 


### PR DESCRIPTION
Hello,

it seems that pip 10 does not allow the use of pip.req (https://stackoverflow.com/questions/25192794/no-module-named-pip-req).
I've tested with this workaround and it seems to work well.