### PR TITLE
Put the list of requirements in setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-future
-six
+# Requirements are listed in setup.py. The dot on the next line refers to
+# the current directory, instructing installers to use this package's setup.py
+.

--- a/setup.py
+++ b/setup.py
@@ -12,30 +12,13 @@ from __future__ import unicode_literals
 
 import io
 from os import path
-try: # for pip >= 10 (From: https://stackoverflow.com/questions/25192794/no-module-named-pip-req)
-    from pip._internal.req import parse_requirements
-except ImportError: # for pip <= 9.0.3
-    from pip.req import parse_requirements
 from setuptools import setup, find_packages
 
 
-def get_requirements(requirements_file):
-    """Use pip to parse requirements file."""
-    requirements = []
-    if path.isfile(requirements_file):
-        for req in parse_requirements(requirements_file, session="hack"):
-            # check markers, such as
-            #
-            #     rope_py3k    ; python_version >= '3.0'
-            #
-            if req.match_markers():
-                requirements.append(str(req.req))
-    return requirements
-
+INSTALL_REQUIRES = ['future', 'six']
 
 if __name__ == "__main__":
     HERE = path.abspath(path.dirname(__file__))
-    INSTALL_REQUIRES = get_requirements(path.join(HERE, "requirements.txt"))
     with io.open(path.join(HERE, "README.rst"), encoding="utf-8") as readme:
         LONG_DESCRIPTION = readme.read()
     setup(


### PR DESCRIPTION
Pip's internal API is unstable and might actually change more often
than the list of requirements.

Put the requirements in setup.py, and refer there from requirements.txt