### PR TITLE
Fix collections import DeprecationWarning

### DIFF
--- a/sievelib/commands.py
+++ b/sievelib/commands.py
@@ -23,8 +23,12 @@ provides extra information such as:
 """
 from __future__ import unicode_literals
 
-from collections import Iterable
 import sys
+
+try:
+    from collections.abc import Iterable
+except ImportError:  # python < 3.3
+    from collections import Iterable
 
 from future.utils import python_2_unicode_compatible
 


### PR DESCRIPTION
Fixes this warning in Python 3.7:

```
/path/to/lib/python3.7/site-packages/sievelib/commands.py:26
  /path/to/lib/python3.7/site-packages/sievelib/commands.py:26: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import Iterable
```