### PR TITLE
Save position (line/col) of parse error.

### DIFF
--- a/sievelib/parser.py
+++ b/sievelib/parser.py
@@ -88,7 +88,7 @@ class Lexer(object):
                 raise ParseError("unknown token %s" % text[self.pos:])
 
             yield (m.lastgroup, m.group(m.lastgroup))
-            self.pos += len(m[0])
+            self.pos += len(m.group(0))
 
 
 class Parser(object):

--- a/sievelib/parser.py
+++ b/sievelib/parser.py
@@ -405,6 +405,7 @@ class Parser(object):
 
         self.__reset_parser()
         try:
+            tvalue = ''
             for ttype, tvalue in self.lexer.scan(text):
                 if ttype == "hash_comment":
                     self.hash_comments += [tvalue.strip()]

--- a/sievelib/parser.py
+++ b/sievelib/parser.py
@@ -59,7 +59,7 @@ class Lexer(object):
     def curlineno(self):
         """Return the current line number"""
         return self.text[:self.pos].count(b'\n') + 1
-    
+
     def curcolno(self):
         """Return the current column number"""
         return self.pos - self.text.rfind(b'\n', 0, self.pos)
@@ -88,7 +88,7 @@ class Lexer(object):
                 raise ParseError("unknown token %s" % text[self.pos:])
 
             yield (m.lastgroup, m.group(m.lastgroup))
-            self.pos = m.end()
+            self.pos += len(m[0])
 
 
 class Parser(object):

--- a/sievelib/parser.py
+++ b/sievelib/parser.py
@@ -440,7 +440,7 @@ class Parser(object):
                                  "|".join(self.__expected))
 
         except (ParseError, CommandError) as e:
-            self.error_pos = (self.lexer.curlineno(), self.lexer.curcolno())
+            self.error_pos = (self.lexer.curlineno(), self.lexer.curcolno(), len(tvalue))
             self.error = "line %d: %s" % (self.error_pos[0], str(e))
             return False
         return True


### PR DESCRIPTION
Currently, the Lexer pos is at the _end_ of the current token during `yield`. This means that the start position of the error cannot be reproduced. By updating the pos _after_ the yield, we can determine the first broken byte.

Then, upon parse error, we can save `error_pos = (line, col)`, which can be used to e.g. jump to the beginning of the error in a text editor. Otherwise, the best you could do is jump to the _end_ of the error, which is counter-intuitive.

This also effects the error messages, which no longer claim that the error is at the end of the token, but its start.