### PR TITLE
Remove support for outdated Python versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ language: python
 cache: pip
 
 python:
-  - '2.7'
-  - '3.4'
-  - '3.6'
+  - '3.5'
+  - '3.8'
 
 before_install:
   - pip install codecov nose
@@ -27,4 +26,4 @@ deploy:
   distributions: sdist bdist_wheel
   on:
     tags: true
-    python: '3.6'
+    python: '3.8'

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """
 A setuptools based setup module.
@@ -8,14 +7,10 @@ See:
 https://packaging.python.org/en/latest/distributing.html
 """
 
-from __future__ import unicode_literals
-
 import io
 from os import path
 from setuptools import setup, find_packages
 
-
-INSTALL_REQUIRES = ['future', 'six']
 
 if __name__ == "__main__":
     HERE = path.abspath(path.dirname(__file__))
@@ -31,7 +26,7 @@ if __name__ == "__main__":
         url="https://github.com/tonioo/sievelib",
         license="MIT",
         keywords=["sieve", "managesieve", "parser", "client"],
-        install_requires=INSTALL_REQUIRES,
+        install_requires=[],
         setup_requires=["setuptools_scm"],
         use_scm_version=True,
         classifiers=[

--- a/sievelib/__init__.py
+++ b/sievelib/__init__.py
@@ -1,8 +1,4 @@
-# -*- coding: utf-8 -*-
-
 """sievelib."""
-
-from __future__ import unicode_literals
 
 from pkg_resources import get_distribution, DistributionNotFound
 

--- a/sievelib/commands.py
+++ b/sievelib/commands.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 """
 SIEVE commands representation
 
@@ -21,17 +19,8 @@ provides extra information such as:
  * etc.
 
 """
-from __future__ import unicode_literals
-
 import sys
-
-try:
-    from collections.abc import Iterable
-except ImportError:  # python < 3.3
-    from collections import Iterable
-
-from future.utils import python_2_unicode_compatible
-
+from collections.abc import Iterable
 from . import tools
 
 
@@ -41,7 +30,6 @@ class CommandError(Exception):
     pass
 
 
-@python_2_unicode_compatible
 class UnknownCommand(CommandError):
     """Specific exception raised when an unknown command is encountered"""
 
@@ -52,7 +40,6 @@ class UnknownCommand(CommandError):
         return "unknown command %s" % self.name
 
 
-@python_2_unicode_compatible
 class BadArgument(CommandError):
     """Specific exception raised when a bad argument is encountered"""
 
@@ -66,7 +53,6 @@ class BadArgument(CommandError):
                % (self.seen, self.command, self.expected)
 
 
-@python_2_unicode_compatible
 class BadValue(CommandError):
     """Specific exception raised when a bad argument value is encountered"""
 
@@ -79,7 +65,6 @@ class BadValue(CommandError):
                % (self.value, self.argument)
 
 
-@python_2_unicode_compatible
 class ExtensionNotLoaded(CommandError):
     """Raised when an extension is not loaded."""
 

--- a/sievelib/digest_md5.py
+++ b/sievelib/digest_md5.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 """
 Simple Digest-MD5 implementation (client side)
 

--- a/sievelib/factory.py
+++ b/sievelib/factory.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 """
 Tools for simpler sieve filters generation.
 
@@ -10,17 +8,12 @@ Only commands (control/test/action) defined in the ``commands`` module
 are supported.
 """
 
-from __future__ import print_function, unicode_literals
-
+import io
 import sys
-
-from future.utils import python_2_unicode_compatible
-import six
 
 from sievelib import commands
 
 
-@python_2_unicode_compatible
 class FiltersSet(object):
 
     """A set of filters."""
@@ -42,7 +35,7 @@ class FiltersSet(object):
         self.filters = []
 
     def __str__(self):
-        target = six.StringIO()
+        target = io.StringIO()
         self.tosieve(target)
         ret = target.getvalue()
         target.close()
@@ -74,7 +67,7 @@ class FiltersSet(object):
             name = "Unnamed rule %d" % cpt
             description = ""
             for comment in f.hash_comments:
-                if isinstance(comment, six.binary_type):
+                if isinstance(comment, bytes):
                     comment = comment.decode("utf-8")
                 if comment.startswith(self.filter_name_pretext):
                     name = comment.replace(self.filter_name_pretext, "")
@@ -276,7 +269,7 @@ class FiltersSet(object):
     def _unicode_filter_name(self, name):
         """Convert name to unicode if necessary."""
         return (
-            name.decode("utf-8") if isinstance(name, six.binary_type) else name
+            name.decode("utf-8") if isinstance(name, bytes) else name
         )
 
     def addfilter(self, name, conditions, actions, matchtype="anyof"):

--- a/sievelib/managesieve.py
+++ b/sievelib/managesieve.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 """
 A MANAGESIEVE client.
 
@@ -9,15 +7,10 @@ a user to syntactically flawed scripts.
 
 Implementation based on RFC 5804.
 """
-from __future__ import print_function
-
 import base64
 import re
 import socket
 import ssl
-
-from future.utils import python_2_unicode_compatible
-import six
 
 from .digest_md5 import DigestMD5
 from . import tools
@@ -36,7 +29,6 @@ class Error(Exception):
     pass
 
 
-@python_2_unicode_compatible
 class Response(Exception):
     def __init__(self, code, data):
         self.code = code
@@ -46,7 +38,6 @@ class Response(Exception):
         return "%s %s" % (self.code, self.data)
 
 
-@python_2_unicode_compatible
 class Literal(Exception):
     def __init__(self, value):
         self.value = value
@@ -227,7 +218,7 @@ class Client(object):
         """
         ret = []
         for a in args:
-            if isinstance(a, six.binary_type):
+            if isinstance(a, bytes):
                 if self.__size_expr.match(a):
                     ret += [a]
                 else:
@@ -268,9 +259,9 @@ class Client(object):
                 self.sock.sendall(l + CRLF)
         code, data, content = self.__read_response(nblines)
 
-        if isinstance(code, six.binary_type):
+        if isinstance(code, bytes):
             code = code.decode("utf-8")
-        if isinstance(data, six.binary_type):
+        if isinstance(data, bytes):
             data = data.decode("utf-8")
 
         if withcontent:
@@ -328,9 +319,9 @@ class Client(object):
         :param password: clear password
         :return: True on success, False otherwise.
         """
-        if isinstance(login, six.text_type):
+        if isinstance(login, str):
             login = login.encode("utf-8")
-        if isinstance(password, six.text_type):
+        if isinstance(password, str):
             password = password.encode("utf-8")
         params = base64.b64encode(b'\0'.join([authz_id, login, password]))
         code, data = self.__send_command("AUTHENTICATE", [b"PLAIN", params])
@@ -478,7 +469,7 @@ class Client(object):
 
         :rtype: string
         """
-        if isinstance(self.__capabilities["SIEVE"], six.string_types):
+        if isinstance(self.__capabilities["SIEVE"], str):
             self.__capabilities["SIEVE"] = self.__capabilities["SIEVE"].split()
         return self.__capabilities["SIEVE"]
 

--- a/sievelib/parser.py
+++ b/sievelib/parser.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding: utf-8
 
 """
 This module provides a simple but functional parser for the SIEVE
@@ -8,19 +7,13 @@ language used to filter emails.
 This implementation is based on RFC 5228 (http://tools.ietf.org/html/rfc5228)
 
 """
-from __future__ import print_function
-
 import re
 import sys
-
-from future.utils import python_2_unicode_compatible, text_type
-import six
 
 from sievelib.commands import (
     get_command_instance, CommandError, RequireCommand)
 
 
-@python_2_unicode_compatible
 class ParseError(Exception):
     """Generic parsing error"""
 
@@ -48,9 +41,7 @@ class Lexer(object):
         self.definitions = definitions
         parts = []
         for name, part in definitions:
-            param = "(?P<%s>%s)" % (name.decode(), part.decode())
-            if six.PY3:
-                param = bytes(param, "utf-8")
+            param = b"(?P<%s>%s)" % (name, part)
             parts.append(param)
         self.regexpString = b"|".join(parts)
         self.regexp = re.compile(self.regexpString, re.MULTILINE)
@@ -404,7 +395,7 @@ class Parser(object):
         :param text: a string containing the data to parse
         :return: True on success (no error detected), False otherwise
         """
-        if isinstance(text, text_type):
+        if isinstance(text, str):
             text = text.encode("utf-8")
 
         self.__reset_parser()

--- a/sievelib/tests/test_factory.py
+++ b/sievelib/tests/test_factory.py
@@ -1,8 +1,5 @@
-# coding: utf-8
-from __future__ import unicode_literals
-
 import unittest
-import six
+import io
 
 from sievelib.factory import FiltersSet
 from .. import parser
@@ -168,7 +165,7 @@ if anyof (envelope :contains ["To"] ["hello@world.it"]) {
         self.assertIn("stop", actions[0])
 
     def test_add_header_filter(self):
-        output = six.StringIO()
+        output = io.StringIO()
         self.fs.addfilter(
             "rule1",
             [('Sender', ":is", 'toto@toto.com'), ],
@@ -185,7 +182,7 @@ if anyof (header :is "Sender" "toto@toto.com") {
         output.close()
 
     def test_use_action_with_tag(self):
-        output = six.StringIO()
+        output = io.StringIO()
         self.fs.addfilter(
             "rule1",
             [('Sender', ":is", 'toto@toto.com'), ],
@@ -202,7 +199,7 @@ if anyof (header :is "Sender" "toto@toto.com") {
         output.close()
 
     def test_add_header_filter_with_not(self):
-        output = six.StringIO()
+        output = io.StringIO()
         self.fs.addfilter(
             "rule1",
             [('Sender', ":notcontains", 'toto@toto.com')],
@@ -218,7 +215,7 @@ if anyof (not header :contains "Sender" "toto@toto.com") {
 """)
 
     def test_add_exists_filter(self):
-        output = six.StringIO()
+        output = io.StringIO()
         self.fs.addfilter(
             "rule1",
             [('exists', "list-help", "list-unsubscribe",
@@ -236,7 +233,7 @@ if anyof (exists ["list-help","list-unsubscribe","list-subscribe","list-owner"])
 """)
 
     def test_add_exists_filter_with_not(self):
-        output = six.StringIO()
+        output = io.StringIO()
         self.fs.addfilter(
             "rule1",
             [('notexists', "list-help", "list-unsubscribe",
@@ -254,7 +251,7 @@ if anyof (not exists ["list-help","list-unsubscribe","list-subscribe","list-owne
 """)
 
     def test_add_size_filter(self):
-        output = six.StringIO()
+        output = io.StringIO()
         self.fs.addfilter(
             "rule1",
             [('size', ":over", "100k")],
@@ -287,7 +284,7 @@ if anyof (size :over 100k) {
                           [("fileinto", 'Toto')])
         self.assertIsNot(self.fs.getfilter("rule1"), None)
         self.assertEqual(self.fs.disablefilter("rule1"), True)
-        output = six.StringIO()
+        output = io.StringIO()
         self.fs.tosieve(output)
         self.assertEqual(output.getvalue(), """require ["fileinto"];
 

--- a/sievelib/tests/test_managesieve.py
+++ b/sievelib/tests/test_managesieve.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 """Managesieve test cases."""
 
 import unittest

--- a/sievelib/tests/test_managesieve.py
+++ b/sievelib/tests/test_managesieve.py
@@ -1,10 +1,7 @@
 """Managesieve test cases."""
 
 import unittest
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 from sievelib import managesieve
 

--- a/sievelib/tests/test_parser.py
+++ b/sievelib/tests/test_parser.py
@@ -1,12 +1,10 @@
-# coding: utf-8
-
 """
 Unit tests for the SIEVE language parser.
 """
 import unittest
 import os.path
 import codecs
-import six
+import io
 
 from sievelib.parser import Parser
 from sievelib.factory import FiltersSet
@@ -59,7 +57,7 @@ class SieveTest(unittest.TestCase):
         self.__checkCompilation(script, False)
 
     def representation_is(self, content):
-        target = six.StringIO()
+        target = io.StringIO()
         self.parser.dump(target)
         repr_ = target.getvalue()
         target.close()
@@ -68,7 +66,7 @@ class SieveTest(unittest.TestCase):
     def sieve_is(self, content):
         filtersset = FiltersSet("Testfilterset")
         filtersset.from_parser_result(self.parser)
-        target = six.StringIO()
+        target = io.StringIO()
         filtersset.tosieve(target)
         repr_ = target.getvalue()
         target.close()
@@ -834,7 +832,7 @@ class VariablesCommands(SieveTest):
         self.compilation_ok(b"""require ["variables"];
 
 set "matchsub" "testsubject";
-        
+
 if allof (
   header :contains ["Subject"] "${header}"
 )

--- a/sievelib/tools.py
+++ b/sievelib/tools.py
@@ -1,13 +1,6 @@
 """Some tools."""
 
 
-def to_bytes(s, encoding="utf-8"):
-    """Convert a string to bytes."""
-    if isinstance(s, bytes):
-        return s
-    return bytes(s, encoding)
-
-
 def to_list(stringlist, unquote=True):
     """Convert a string representing a list to real list."""
     stringlist = stringlist[1:-1]

--- a/sievelib/tools.py
+++ b/sievelib/tools.py
@@ -1,15 +1,11 @@
 """Some tools."""
 
-import six
-
 
 def to_bytes(s, encoding="utf-8"):
     """Convert a string to bytes."""
-    if isinstance(s, six.binary_type):
+    if isinstance(s, bytes):
         return s
-    if six.PY3:
-        return bytes(s, encoding)
-    return s.encode(encoding)
+    return bytes(s, encoding)
 
 
 def to_list(stringlist, unquote=True):


### PR DESCRIPTION
Python versions 2.7 and 3.4 have reached their respective end-of-life. Everything should stop supporting them. This will also mean we can drop `six` and `future` as dependencies.