### PR TITLE
Added Support for Linux On Power

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: python
 
 cache: pip
-
+arch:
+  - amd64
+  - ppc64le
 python:
   - '3.5'
   - '3.8'


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/ujjwalsh/sievelib/builds/210337967
Please have a look.

Regards,
ujjwal