### PR TITLE
Fixed Digest-MD5 for Python 3.6+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .*~$
+.eggs
+.venv
 *.pyc
+build
 dist
 sievelib.egg-info


### PR DESCRIPTION
This code was still very much Python 2 only.

A word on why I used `latin` encoding:

This is a synonym for `iso-8859-1` which is the default encoding used in RFC-2831 (Digest MD5 SASL).

Now, Digest-MD5 SASL supports UTF-8 too, but with some caveats. As far as I understand, UTF-8 can only be used under the following conditions:

- Only if the challenge includes `charset=UTF-8`
- Only if the challenge response also includes `charset=UTF-8`
- Either value `username-value`, `realm-value`, `passwd` may only be UTF-8 encoded before hashing if they contain any non-ISO-8859-1 character in them, otherwise the hash must be calculated from the ISO-8859-1 encoding.

Since none of this logic exists in the current implementation, I decided to only use `latin`. Anything else would be a new feature.

Cf. [RFC 2831](https://www.rfc-editor.org/rfc/rfc2831#section-2.1.2)

**Note**: This is mostly untested because I couldn't connect to my test server that supports Digest-MD5 with sievelib, even after manually switching to PLAIN/LOGIN. It works with other ManageSieve clients, so I assume there is another, perhaps unrelated, bug in this library somewhere. Honestly, I don't have the time to fully track down that issue and will likely be using the other client going forward. However, with these changes, it did at least _try_ to connect without raising random exceptions, so I wanted to at least share my effort.