### PR TITLE
fix starttls

### DIFF
--- a/sievelib/managesieve.py
+++ b/sievelib/managesieve.py
@@ -486,7 +486,7 @@ class Client:
             context.load_cert_chain(certfile, keyfile=keyfile)
         try:
             # nsock = ssl.wrap_socket(self.sock, keyfile, certfile)
-            nsock = context.wrap_socket(self.sock)
+            nsock = context.wrap_socket(self.sock, server_hostname=self.srvaddr)
         except ssl.SSLError as e:
             raise Error("SSL error: %s" % str(e))
         self.sock = nsock

--- a/sievelib/managesieve.py
+++ b/sievelib/managesieve.py
@@ -481,10 +481,12 @@ class Client:
         code, data = self.__send_command("STARTTLS")
         if code != "OK":
             return False
-        context = ssl.SSLContext()
+        context = ssl.create_default_context()
+        if certfile is not None:
+            context.load_cert_chain(certfile, keyfile=keyfile)
         try:
             # nsock = ssl.wrap_socket(self.sock, keyfile, certfile)
-            nsock = context.wrap_socket(self.sock, keyfile, certfile)
+            nsock = context.wrap_socket(self.sock)
         except ssl.SSLError as e:
             raise Error("SSL error: %s" % str(e))
         self.sock = nsock


### PR DESCRIPTION
- ssl.SSLContext.wrap_socket() does not accept certfile= and keyfile arguments
- use ssl.create_default_context() to create SSLContext object
- use SSLContext.load_cert_chain() to load eventual client key material