### PR TITLE
Devcontainer + Fix python 3.13 warning

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.13-slim
+
+# Install Java
+RUN apt update &&  \
+    apt install -y curl telnet git
+
+## Pip dependencies
+# Upgrade pip
+RUN pip install --upgrade pip
+
+# Install production dependencies
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt && \
+    rm /tmp/requirements.txt
+
+# Install development dependencies
+COPY dev-requirements.txt /tmp/requirements-dev.txt
+RUN pip install -r /tmp/requirements-dev.txt && \
+    rm /tmp/requirements-dev.txt

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": ".."
+    }
+}

--- a/sievelib/managesieve.py
+++ b/sievelib/managesieve.py
@@ -178,7 +178,7 @@ class Client:
         return ret
 
     def __read_response(self, nblines: int = -1) -> Tuple[bytes, bytes, bytes]:
-        """Read a response from the server.
+        r"""Read a response from the server.
 
         In the usual case, we read lines until we find one that looks
         like a response (OK|NO|BYE\s*(.+)?).
@@ -214,7 +214,7 @@ class Client:
         return (code, data, resp)
 
     def __prepare_args(self, args: List[Any]) -> List[bytes]:
-        """Format command arguments before sending them.
+        r"""Format command arguments before sending them.
 
         Command arguments of type string must be quoted, the only
         exception concerns size indication (of the form {\d\+?}).
@@ -307,7 +307,7 @@ class Client:
         return True
 
     def __parse_error(self, text: bytes):
-        """Parse an error received from the server.
+        r"""Parse an error received from the server.
 
         if text corresponds to a size indication, we grab the
         remaining content from the server.

--- a/sievelib/parser.py
+++ b/sievelib/parser.py
@@ -25,7 +25,7 @@ class ParseError(Exception):
 
 
 class Lexer:
-    """
+    r"""
     The lexical analysis part.
 
     This class provides a simple way to define tokens (with patterns)


### PR DESCRIPTION
Hello,
I'm planning to make some PR to add missing functionalities.
To do so, I'm using a devcontainer and wonder if you'll be interested to have it on your repo.

Besides, using pyhton 3.13, there were some warning when importing modules, as you can see below:
![warning](https://github.com/user-attachments/assets/44f67b30-5178-4af6-a0b0-ff100158d63e)

I've fixed them in this PR too. But if you don't want the devcontainer, I can remove it from the PR and just put the fixes.

Also, if you want me to open an issue before making a PR ask away!

Cheers,
Quentin