### PR TITLE
Support implicit TLS connections

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,6 +134,8 @@ it.
 
 For the ``AUTHENTICATE`` command, supported mechanisms are ``DIGEST-MD5``,
 ``PLAIN``, ``LOGIN``, ``OAUTHBEARER`` and ``XOAUTH2``.
+
+Both explicit TLS via STARTTLS and implicit TLS are supported.
     
 Basic usage
 ^^^^^^^^^^^


### PR DESCRIPTION
This PR add support for implicit TLS connections which some servers (e.g. Stalwart) offer. I would normally have renamed the `starttls` parameter to a more general `tls` parameter that takes explicit/implicit/None, but this wouldn't be backwards compatible without messy migration code. If you prefer just changing the API and bumping the major version let me know.